### PR TITLE
adding missing Dependency to czechboy0/Environment - fix failed build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,5 +5,6 @@ let package = Package(
     targets: [],
     dependencies: [
         .Package(url: "https://github.com/onevcat/Rainbow", majorVersion: 1),
+	.Package(url: "https://github.com/czechboy0/Environment.git", majorVersion: 0)
     ]
 )

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dP                         dP       M''''''''M M''MMMMM''M
 ## Dependencies
 - [libcaca](http://caca.zoy.org/)
 - [mplayer](https://www.mplayerhq.hu/)
-- [Swift](https://swift.org/download/#latest-development-snapshots)
+- [Swift 3.0+](https://swift.org/download/#latest-development-snapshots)
 
 **Note that the latest mplayer does not link to libcaca by default (at least on Mac OS)**
 


### PR DESCRIPTION
Build failed at my mac because it could not import 'Environment'. I just googled for such a package and found https://github.com/czechboy0/Environment

Adding this as dependency to the Package.swift fixed the build in my case.

I am using latest swift dev snapshot
`Apple Swift version 3.0-dev (LLVM a7663bb722, Clang 4ca3c7fa28, Swift 1c2f40e246)
Target: x86_64-apple-macosx10.9`
